### PR TITLE
feat: enhance output type handling in pushvar key processing

### DIFF
--- a/src/lemniscat/plugin/azurecli/azurecli.py
+++ b/src/lemniscat/plugin/azurecli/azurecli.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # above is for compatibility of python2.7.11
 
+import json
 import logging
 import os
 import subprocess, sys
@@ -61,12 +62,22 @@ class AzureCli:
                         log.warning(f'  {line[1:]}')
                 if line[0] == '1':
                     ltrace = line[1:]
-                    m = re.match(r"^\[lemniscat\.pushvar(?P<secret>\.secret)?\] (?P<key>[^=]+)=(?P<value>.*)", str(ltrace))
+                    m = re.match(r"^\[lemniscat\.pushvar(?P<secret>\.secret)?\(?(?P<outputType>string|json|int|float|bool)?\)?\] (?P<key>[^=]+)=(?P<value>.*)", str(ltrace))
                     if(not m is None):
+                        value = m.group('value').strip()
+                        if(m.group('outputType') == 'json'):
+                            value = json.loads(value)
+                        elif(m.group('outputType') == 'int'):
+                            value = int(value)
+                        elif(m.group('outputType') == 'bool'):
+                            value = value.lower() == 'true'
+                        elif(m.group('outputType') == 'float'):
+                            value = float(value)
+
                         if(m.group('secret') == '.secret'):
-                            outputVar[m.group('key').strip()] = VariableValue(m.group('value').strip(), True)
+                            outputVar[m.group('key').strip()] = VariableValue(value, True)
                         else:
-                            outputVar[m.group('key').strip()] = VariableValue(m.group('value').strip())
+                            outputVar[m.group('key').strip()] = VariableValue(value)
                     else:
                         log.info(f'  {ltrace}')
 


### PR DESCRIPTION
This pull request introduces enhancements to the `azurecli.py` file within the `lemniscat` plugin. The primary changes involve importing the `json` module and updating the `cmd` method to handle different output types.

Key changes include:

* [`src/lemniscat/plugin/azurecli/azurecli.py`](diffhunk://#diff-901e895ba651413a9fa6180efc211aad098a8a3c35d8202334fa3d97ba011732R4): Added import statement for the `json` module to handle JSON data.

Enhancements to `cmd` method:

* [`src/lemniscat/plugin/azurecli/azurecli.py`](diffhunk://#diff-901e895ba651413a9fa6180efc211aad098a8a3c35d8202334fa3d97ba011732L64-R80): Modified the regular expression in the `cmd` method to capture an optional output type (`string`, `json`, `int`, `float`, `bool`).
* [`src/lemniscat/plugin/azurecli/azurecli.py`](diffhunk://#diff-901e895ba651413a9fa6180efc211aad098a8a3c35d8202334fa3d97ba011732L64-R80): Updated the `cmd` method to process the captured output type and convert the value accordingly (e.g., parsing JSON, converting to int, float, or bool).